### PR TITLE
Fix file dialog opens twice

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -413,7 +413,6 @@ function saveJSON(){
 function loadJSON(){
     const input = document.createElement("input");
     input.type = "file"
-    input.click()
     input.addEventListener("change", function(e){
         const file = e.target.files[0];
 		var fileReader = new FileReader();


### PR DESCRIPTION
When I click on "Load from JSON", it open up the file dialog twice. And this is the fix.