### PR TITLE
Avoid calling detectImage with empty string

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -317,7 +317,7 @@ function initCanvas(elem){
         if(gradioApp().querySelector('#tab_openpose_editor').style.display!=='block') return;
         try {
             const raw = gradioApp().querySelector("#jsonbox").querySelector("textarea").value
-            detectImage(raw)
+            if(raw.length!==0) detectImage(raw);
         } catch(e){console.log(e)}
     })
     json_observer.observe(gradioApp().querySelector("#jsonbox"), { "attributes": true })


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22171828/227760533-16b59764-9933-495f-b2d8-4bac95ea3283.png)

Check if `raw` is empty string before calling `detectImage`.