### PR TITLE
Add timestamp suffix to saved json name for avoid conflict

### DIFF
--- a/javascript/main.js
+++ b/javascript/main.js
@@ -380,9 +380,10 @@ function saveJSON(){
     const blob = new Blob([json], {
         type: "application/json"
     });
+    const filename = "pose-" + Date.now().toString() + ".json"
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
-    a.download = "pose.json";
+    a.download = filename;
     a.click();
     URL.revokeObjectURL(a.href);
 }


### PR DESCRIPTION
### Why
the fixed name `pose.json` creates a bit of confusion in the directory

### What
add timestamp suffix to saved json name 

### Verify

<img src="https://user-images.githubusercontent.com/128375799/227983104-6c32be4e-5adf-4d66-9d6d-bd7de10d8271.png" width="500" >



Thanks so much for such a useful tool!
